### PR TITLE
Fix typehinting

### DIFF
--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -92,9 +92,4 @@ class Player extends Model
     {
         $this->update(['available_ballots' => $this->available_ballots - 1]);
     }
-
-    // public function getAvailableVotesAttribute()
-    // {
-    //     return $this->game->rounds()->started()->count();
-    // }
 }

--- a/app/Projectors/AvailableBallotsProjector.php
+++ b/app/Projectors/AvailableBallotsProjector.php
@@ -8,17 +8,17 @@ use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
 
 class AvailableBallotsProjector extends Projector
 {
-    public function onBallotGained(BallotGained $player_gained_ballot)
+    public function onBallotGained(BallotGained $event)
     {
-        $player_gained_ballot->player->update([
-            'available_ballots' => $player_gained_ballot->player->available_ballots++
+        $event->player->update([
+            'available_ballots' => $event->player->available_ballots++,
         ]);
     }
 
-    public function onBallotSubmitted(BallotSubmitted $player_gained_ballot)
+    public function onBallotSubmitted(BallotSubmitted $event)
     {
-        $player_gained_ballot->voter->update([
-            'available_ballots' => $player_gained_ballot->voter->available_ballots--
+        $event->voter->update([
+            'available_ballots' => $event->voter->available_ballots--,
         ]);
     }
 }

--- a/app/Projectors/BallotProjector.php
+++ b/app/Projectors/BallotProjector.php
@@ -3,20 +3,18 @@
 namespace App\Projectors;
 
 use App\Models\Ballot;
-use App\StorableEvents\BallotGained;
 use App\StorableEvents\BallotSubmitted;
 use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
-use Spatie\EventSourcing\StoredEvents\StoredEvent;
 
 class BallotProjector extends Projector
 {
-    public function onBallotSubmitted(BallotSubmitted $ballot_submitted)
+    public function onBallotSubmitted(BallotSubmitted $event)
     {
         Ballot::create([
-            'player_id' => $ballot_submitted->voter->id,
-            'upvote_id' => $ballot_submitted->upvote_target->id,
-            'downvote_id' => $ballot_submitted->downvote_target->id,
-            'round_id' => $ballot_submitted->round->id,
+            'player_id' => $event->voter->id,
+            'upvote_id' => $event->upvote_target->id,
+            'downvote_id' => $event->downvote_target->id,
+            'round_id' => $event->round->id,
         ]);
     }
 }

--- a/app/Projectors/DownvoteProjector.php
+++ b/app/Projectors/DownvoteProjector.php
@@ -7,8 +7,8 @@ use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
 
 class DownvoteProjector extends Projector
 {
-    public function onBallotSubmitted(BallotSubmitted $ballot_submitted)
+    public function onBallotSubmitted(BallotSubmitted $event)
     {
-        $ballot_submitted->downvote_target->update(['tally' => $ballot_submitted->downvote_target->tally--]);
+        $event->downvote_target->update(['tally' => $event->downvote_target->tally--]);
     }
 }

--- a/app/Projectors/UpvoteProjector.php
+++ b/app/Projectors/UpvoteProjector.php
@@ -2,7 +2,7 @@
 
 namespace App\Projectors;
 
-
+use App\StorableEvents\BallotSubmitted;
 use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
 
 class UpvoteProjector extends Projector

--- a/app/Projectors/UpvoteProjector.php
+++ b/app/Projectors/UpvoteProjector.php
@@ -2,13 +2,13 @@
 
 namespace App\Projectors;
 
-use App\StorableEvents\BallotSubmitted;
+
 use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
 
 class UpvoteProjector extends Projector
 {
-    public function onBallotSubmitted(BallotSubmitted $ballot_submitted)
+    public function onBallotSubmitted(BallotSubmitted $event)
     {
-        $ballot_submitted->upvote_target->update(['tally' => $ballot_submitted->upvote_target->tally++]);
+        $event->upvote_target->update(['tally' => $event->upvote_target->tally++]);
     }
 }

--- a/database/factories/PlayerFactory.php
+++ b/database/factories/PlayerFactory.php
@@ -17,12 +17,13 @@ class PlayerFactory extends Factory
         return [
             'user_id' => User::factory(),
             'game_id' => Game::factory(),
+            'tally' => 0,
         ];
     }
 
     public function onTeam(Team $team = null)
     {
-        return $this->state(function($attributes) use ($team) {
+        return $this->state(function ($attributes) use ($team) {
             $team = $team ?? Team::factory()->game(Game::find($attributes['game_id']))->create();
 
             return [
@@ -33,7 +34,7 @@ class PlayerFactory extends Factory
 
     public function game(Game $game)
     {
-        return $this->state(fn($attributes) => [
+        return $this->state(fn ($attributes) => [
             'game_id' => $game->id,
         ]);
     }

--- a/database/migrations/2021_01_23_035433_create_players_table.php
+++ b/database/migrations/2021_01_23_035433_create_players_table.php
@@ -18,6 +18,7 @@ class CreatePlayersTable extends Migration
             $table->foreignIdFor(User::class);
             $table->foreignIdFor(Team::class)->nullable();
             $table->integer('available_ballots')->default(0);
+            $table->integer('tally')->default(0);
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Turns out when you type-hint the event in methods on the Projector you need to name the parameter `$event`

So the tests are now passing for the event-sourced ballot submission